### PR TITLE
Setup Cascade Studio public path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,12 @@ import path from 'path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+// Configuration Vite pour l'application
 export default defineConfig({
+  // Chemin de base de l'application
+  base: '/',
+  // Dossier public contenant Cascade Studio
+  publicDir: 'public',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure `vite.config.ts` with `base` and `publicDir` so assets like `/cascade-studio/` are served correctly

## Testing
- `npm run lint` *(fails: 66 errors)*
- `npm run test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6855137ef9b8832383aa18b4a384fe2a