### PR TITLE
Implémente la géométrie via createPanelGeometry

### DIFF
--- a/src/brep/createPanelGeometry.ts
+++ b/src/brep/createPanelGeometry.ts
@@ -1,0 +1,13 @@
+import { BufferGeometry } from 'three';
+import { genererPanneauBois, PanneauDimensions } from './panneauboisBREP';
+
+/**
+ * Enveloppe simplifiée pour générer la géométrie d'un panneau bois.
+ * Permet d'abstraire la génération BREP via le worker.
+ * @param dims Dimensions du panneau en millimètres
+ */
+export async function createPanelGeometry(
+  dims: PanneauDimensions
+): Promise<BufferGeometry> {
+  return genererPanneauBois(dims);
+}

--- a/src/models/PanneauBois.tsx
+++ b/src/models/PanneauBois.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useFrame, type ThreeEvent } from '@react-three/fiber';
 import { Mesh, LineSegments, BoxGeometry, BufferGeometry } from 'three';
 import { useConfigurateurStore } from '@/store/configurateurStore';
-import { genererPanneauBois } from '@/brep/panneauboisBREP';
+import { createPanelGeometry } from '@/brep/createPanelGeometry';
 
 /**
  * Props du composant PanneauBois
@@ -31,7 +31,7 @@ export function PanneauBois({ position = [0, 0, 0] }: PanneauBoisProps) {
 
   // Génère la géométrie BREP lorsqu'une dimension change
   useEffect(() => {
-    genererPanneauBois({
+    createPanelGeometry({
       longueur: dimensions.longueur,
       largeur: dimensions.largeur,
       epaisseur: dimensions.epaisseur,
@@ -74,7 +74,6 @@ export function PanneauBois({ position = [0, 0, 0] }: PanneauBoisProps) {
         onPointerLeave={() => setIsHovered(false)}
         geometry={geomBREP ?? undefined}
       >
-        {!geomBREP && <boxGeometry args={[longueur, largeur, epaisseur]} />}
         <meshLambertMaterial
           color={isHovered ? '#d2691e' : '#daa520'}
           transparent


### PR DESCRIPTION
## Notes
- ajout d'un wrapper `createPanelGeometry` s'appuyant sur `genererPanneauBois`
- mise à jour du modèle `PanneauBois` pour utiliser cette fonction et passer la géométrie générée au `<mesh>`
- exécution de `prettier`, `eslint` et `npm test` (aucun test présent)


------
https://chatgpt.com/codex/tasks/task_e_68553798eb3c8323a49a63eaccbd67be